### PR TITLE
Tweak startup ordering

### DIFF
--- a/robophery/files/robophery-manager.service
+++ b/robophery/files/robophery-manager.service
@@ -2,7 +2,8 @@
 
 [Unit]
 Description=robophery manager
-After=network.target
+Wants=mosquitto.service
+After=network.target mosquitto.service
 
 [Service]
 Type=simple
@@ -11,5 +12,8 @@ Group=root
 WorkingDirectory={{ server.dir.base }}
 Environment=ROBOPHERY_CONF=/etc/robophery
 ExecStart={{ server.dir.base }}/bin/rp_manager
+RestartSec=5
+Restart=on-failure
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The robophery-manager should start after the mosquitto service, if available.
If the mosquitto service is not available on local node, the robophery-manager
should not require it.